### PR TITLE
メインブランチを `main` にリネーム

### DIFF
--- a/Documentation/BugFix.md
+++ b/Documentation/BugFix.md
@@ -1,7 +1,7 @@
 # アプリの不具合を修正をする
 
 ## 課題
-- `master`ブランチの `Example/`配下のアプリに最低4つ不具合が潜んでいます。
+- `main`ブランチの `Example/`配下のアプリに最低4つ不具合が潜んでいます。
 - 全ての不具合を修正しましょう。
 - このリポジトリを[**Duplicate**](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/duplicating-a-repository)したものを作業用リポジトリとしてください。
-- `master`ブランチから作業ブランチを作成し、`master`にマージするPRを提出してください。
+- `main`ブランチから作業ブランチを作成し、`main`にマージするPRを提出してください。


### PR DESCRIPTION
リポ自体がまだ対応されていないですが、まあ一応世の流れ的に `master` ブランチを `main` に直した方がいいかと思って()