### PR TITLE
Error type の jsonDecodeError 削除漏れを削除

### DIFF
--- a/Documentation/YumemiWeather.md
+++ b/Documentation/YumemiWeather.md
@@ -129,7 +129,6 @@ YumemiWeatherError
 ```swift
 public enum YumemiWeatherError: Swift.Error {
     case invalidParameterError
-    case jsonDecodeError
     case unknownError
 }
 ```


### PR DESCRIPTION
# 背景
- jsonDecodeError は過去の対応で削除済み
  - https://github.com/yumemi-inc/ios-training/pull/2
- YumemiWeather のドキュメントに削除漏れと思われるものを発見

# 対応
- Error type から jsonDecodeError を削除

問題なさそうだったので PR を作らせていただきました。問題ありそうでしたらクローズしちゃってください 🙏 