### PR TITLE
Session6のWork with View Controllersリンクを更新

### DIFF
--- a/Documentation/VC_Lifecycle.md
+++ b/Documentation/VC_Lifecycle.md
@@ -4,8 +4,8 @@ UIViewControllerのライフサイクルに関するリファレンスをまと�
 各コールバック関数に`print`を入れて、動作を確認してみると良いです。
 
 ### Viewの生成、表示、非表示
-[Work with View Controllers](https://developer.apple.com/library/archive/referencelibrary/GettingStarted/DevelopiOSAppsSwift/WorkWithViewControllers.html#//apple_ref/doc/uid/TP40015214-CH6-SW1)  
-※`Understand the View Controller Lifecycle`の項  
+[UIViewController](https://developer.apple.com/documentation/uikit/uiviewcontroller)  
+※`Handling View-Related Notifications`の項  
 
 ### レイアウト調整
 [viewWillLayoutSubviews](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621437-viewwilllayoutsubviews)  


### PR DESCRIPTION
fixes #20

# 変更内容
[Session6](https://github.com/yumemi-inc/ios-training/blob/main/Documentation/VC_Lifecycle.md)のWork with ViewControllersがSwiftUIのドキュメントにリダイレクトされてしまうので、UIViewControllerのレファレンスページへのリンクに変更しました。

# 変更理由
非公式ですが、[翻訳されたアーカイブの記事](https://rusutikaa.github.io/docs/developer.apple.com/library/archive/referencelibrary/GettingStarted/DevelopiOSAppsSwift/WorkWithViewControllers.html)からおそらくこの図のライフサイクルについてリファレンスしたかったと推測しました。
[UIViewControllerのAPIリファレンスページ](https://developer.apple.com/documentation/uikit/uiviewcontroller)に同様の図があったのでこちらをリンク先として設定しました。

| 翻訳されたアーカイブの記事 | UIViewControllerのAPIリファレンスページ |
| -- | -- |
| <img width="699" alt="Screen Shot 2022-04-04 at 23 53 23" src="https://user-images.githubusercontent.com/5770480/161571145-8655021e-291c-4179-822b-61aacfdb77ab.png"> | <img width="838" alt="Screen Shot 2022-04-04 at 23 55 06" src="https://user-images.githubusercontent.com/5770480/161571563-c7cebf7c-896c-44b9-ba2d-9118d79b703a.png"> |

# レビュー観点
Session6のリファレンスとしてリンク先が適切かどうか

