### PR TITLE
Delegateパターンにヒントを追加

### DIFF
--- a/Documentation/Delegate.md
+++ b/Documentation/Delegate.md
@@ -17,3 +17,8 @@ UITableViewはUITableViewDelegateの実装クラスを保持し、必要な時�
 - Delegateパターンを使い、APIから天気予報を受け取る
 - ViewControllerに`deinit`を実装し、ログを出力するようにしておく
 - ViewControllerを閉じた時に`deinit`が呼ばれることを確認する
+
+## ヒント
+- 結果を受け取る Delegate の例としては、位置情報をリクエストして結果を受け取る [CLLocationManager](https://developer.apple.com/documentation/corelocation/cllocationmanager) と [CLLocationManagerDelegate](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate) の関係が今回のやりたいことのイメージに近いです
+- [func requestLocation()](https://developer.apple.com/documentation/corelocation/cllocationmanager/1620548-requestlocation) で位置情報をリクエストし、位置情報の更新が発生したら [func locationManager(CLLocationManager, didUpdateLocations: [CLLocation])](https://developer.apple.com/documentation/corelocation/cllocationmanagerdelegate/1423615-locationmanager) で更新された位置情報を受け取ることができます
+- これを今回の課題に置き換えると、天気予報をリクエストし、天気予報の更新が発生したら、更新された天気予報を受け取る、とすると実装をイメージがつかみやすいと思います


### PR DESCRIPTION
現在進行中の研修において、 Delegateパターンにヒントが必要だと感じました。

#27 のレビュー時の指摘がまさにという感じです。

> 今の内容ですと割と結構進んでる前提の説明の仕方になってる気がしまして…例えばこの段階ですと初心者の場合はまだ Delegate という単語をそこまでたくさん目にしてないと思いますし、Cocoaについもてそんなに馴染みがあるわけではないと思いますよね… 🤔
> 
> https://github.com/yumemi-inc/ios-training/pull/27#issuecomment-1127272869

レビューでこの PR の変更内容として追記した指摘をすることになったので、それならば最初から書いてしまった方が親切なのと、今後のレビューコストを下げられる効果を期待しています。

ヒントを追加する懸念としては、おそらく命名を WeatherManager に誘導してしまうこと。
以前の課題の順番だったり、最初から Model Objects を意識していると WeatherModel が主流でした。

一方で、 YumemiWeather Service を manage するクラスとして WeatherManager という命名は悪くないかもとも思ったりしています。

Core Location services をうまく管理するクラスとして CLLocationManager があることからも。

> You use instances of this class to configure, start, and stop the Core Location services.
> 
> https://developer.apple.com/documentation/corelocation/cllocationmanager