### PR TITLE
pull to refresh のリンク修正

### DIFF
--- a/Documentation/UITableView.md
+++ b/Documentation/UITableView.md
@@ -14,8 +14,7 @@
 
 ### エクストラ
 
-- [pull to refresh](https://developer.apple.com/design/human-interface-guidelines/ios/controls/refresh-content-controls/
-)機能を追加する
+- [pull to refresh](https://developer.apple.com/design/human-interface-guidelines/progress-indicators/#Refresh-content-controls)機能を追加する
 
 ## 附録
 [関連ワード・動画索引（熊谷さんのやさしい Swift 勉強会）](https://yumemi.notion.site/786fe804ef4d4a65ba9b24498202d0da)


### PR DESCRIPTION
Apple HIG のサイトが更新されたため

- fixes #47 