### PR TITLE
capitalized elements of `areas` inside fetchWeatherList

### DIFF
--- a/Sources/YumemiWeather/YumemiWeatherList.swift
+++ b/Sources/YumemiWeather/YumemiWeatherList.swift
@@ -68,7 +68,7 @@ public extension YumemiWeather {
             throw YumemiWeatherError.unknownError
         }
 
-        let areas = request.areas.isEmpty ? Area.allCases : request.areas.compactMap { Area(rawValue: $0) }
+        let areas = request.areas.isEmpty ? Area.allCases : request.areas.compactMap { Area(rawValue: $0.capitalized) }
         let response = areas.map { area -> AreaResponse in
             var hasher = Hasher()
             hasher.combine(area)


### PR DESCRIPTION
# Issue
Fixes #49 
fetchWeatherList()の引数areaは第一字が大文字でないと正常に値を返さない。

# 動作確認
<img width="600" alt="Screenshot 2023-10-18 at 13 58 50" src="https://github.com/yumemi-inc/ios-training/assets/9388824/89971cff-b20c-43a7-ace5-5ef63f673034">

<img width="300" alt ="Simulator Screenshot - iPhone 15 Pro - 2023-10-18 at 13 54 48" src="https://github.com/yumemi-inc/ios-training/assets/9388824/5557b317-3d1d-40a3-a435-cfc0761ae76a">
