### PR TITLE
Add GitHub Actions Test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-    name: Build and Test default scheme using any available iPhone simulator
     runs-on: macos-latest
 
     steps:
@@ -24,4 +23,9 @@ jobs:
         run: |
           # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
           device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
-          xcodebuild -scheme "$scheme" test -destination "platform=$platform,name=$device"
+          xcodebuild -scheme "$scheme" -resultBundlePath TestResults test -destination "platform=$platform,name=$device"
+      - name: Format
+        uses: kishikawakatsumi/xcresulttool@v1
+        with:
+          path: TestResults.xcresult
+        if: success() || failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and Test default scheme using any available iPhone simulator
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test
+        env:
+          scheme: ${{ 'YumemiWeather' }}
+          platform: ${{ 'iOS Simulator' }}
+        run: |
+          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
+          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
+          xcodebuild -scheme "$scheme" test -destination "platform=$platform,name=$device"


### PR DESCRIPTION
XCTest を動かす GitHub Actions を追加しました。
以下の PR レビュー時にテストコードを書いてもらってパスすることを確認したいと思ったのが動機です。

- #49 

結果の整形に [xcresulttool](https://github.com/kishikawakatsumi/xcresulttool) を利用しています。
以下のようにテスト結果が表示されます。

https://github.com/yumemi-inc/ios-training/actions/runs/6667656847/job/18121662855