### PR TITLE
fixed Typos on comments on fetch...List() APIs

### DIFF
--- a/Sources/YumemiWeather/YumemiWeatherList.swift
+++ b/Sources/YumemiWeather/YumemiWeatherList.swift
@@ -39,7 +39,7 @@ public extension YumemiWeather {
     /// API に請求する JSON 文字列の例：
     ///
     ///     {
-    ///         "areas": ["tokyo"],
+    ///         "areas": ["Tokyo"],
     ///         "date": "2020-04-01T12:00:00+09:00"
     ///     }
     /// 返された AreaResponse の JSON 文字列の例
@@ -85,7 +85,7 @@ public extension YumemiWeather {
     /// API に請求する JSON 文字列の例：
     ///
     ///     {
-    ///         "areas": ["tokyo"],
+    ///         "areas": ["Tokyo"],
     ///         "date": "2020-04-01T12:00:00+09:00"
     ///     }
     /// 返された AreaResponse の JSON 文字列の例
@@ -114,7 +114,7 @@ public extension YumemiWeather {
     /// API に請求する JSON 文字列の例：
     ///
     ///     {
-    ///         "areas": ["tokyo"],
+    ///         "areas": ["Tokyo"],
     ///         "date": "2020-04-01T12:00:00+09:00"
     ///     }
     ///
@@ -156,7 +156,7 @@ public extension YumemiWeather {
     /// API に請求する JSON 文字列の例：
     ///
     ///     {
-    ///         "areas": ["tokyo"],
+    ///         "areas": ["Tokyo"],
     ///         "date": "2020-04-01T12:00:00+09:00"
     ///     }
     /// 返された AreaResponse の JSON 文字列の例


### PR DESCRIPTION
https://github.com/yumemi-inc/ios-training/issues/49#issuecomment-1808139227 (fetchWeatherList()の引数areaは第一字が大文字でないと正常に値を返さない問題)
で、古宮さんに
> API ReferenceのtypoなのでA案のドキュメント修正が妥当

と教えていただいたので、API Referenceのtypo修正のPRです。

[API reference](https://yumemi-inc.github.io/ios-training/documentation/yumemiweather/yumemiweather/asyncfetchweatherlist(_:))はGitHub Actionで自動生成される？という認識なので、ソースファイル上のコメントのみを修正しました。