### PR TITLE
ci: Use pull_request_target trigger instead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches: [ "main" ]
-  pull_request:
+  pull_request_target:
     branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
With pull_request trigger, we can't attach write permissions to GitHub Actions for the pull requests from a forked repository. This pull request proposes to use pull_request_target trigger instead, so it'll always refer the workflow in the default branch (instead of HEAD), with ability to give write permissions. 