### PR TITLE
スレッドブロックのセッションに非同期テスト対応を明記

### DIFF
--- a/Documentation/ThreadBlock.md
+++ b/Documentation/ThreadBlock.md
@@ -11,8 +11,7 @@ static func syncFetchWeather(_ jsonString: String) throws -> String
 ## 課題
 - 呼び出しAPIを`Sync ver`に変更する
 - APIの処理が戻るまで[UIActivityIndicatorView](https://developer.apple.com/documentation/uikit/uiactivityindicatorview)を表示する
-- 非同期テストに書き換える
-  - [Asynchronous Tests and Expectations](https://developer.apple.com/documentation/xctest/asynchronous_tests_and_expectations)
+- テストがパスすることを確認する
 
 ※イメージ  
 ![thread block](Images/ThreadBlock.gif)
@@ -21,6 +20,10 @@ static func syncFetchWeather(_ jsonString: String) throws -> String
 iOSアプリで時間のかかる処理をするのにどうしたら良いかわからなかったり、何が問題になるのかのヒントを示しておきます。
 
 - [iOSアプリで時間のかかる処理をする](https://zenn.dev/yumemi_inc/articles/ios-ui-thread)
+
+非同期テストが必要になった場合には公式のドキュメントが用意されています。
+
+- [Asynchronous Tests and Expectations](https://developer.apple.com/documentation/xctest/asynchronous_tests_and_expectations)
 
 ## 附録
 [関連ワード・動画索引（熊谷さんのやさしい Swift 勉強会）](https://yumemi.notion.site/b7b5ae4ba0074668acee26de28679ea2)

--- a/Documentation/ThreadBlock.md
+++ b/Documentation/ThreadBlock.md
@@ -11,6 +11,8 @@ static func syncFetchWeather(_ jsonString: String) throws -> String
 ## 課題
 - 呼び出しAPIを`Sync ver`に変更する
 - APIの処理が戻るまで[UIActivityIndicatorView](https://developer.apple.com/documentation/uikit/uiactivityindicatorview)を表示する
+- 非同期テストに書き換える
+  - [Asynchronous Tests and Expectations](https://developer.apple.com/documentation/xctest/asynchronous_tests_and_expectations)
 
 ※イメージ  
 ![thread block](Images/ThreadBlock.gif)


### PR DESCRIPTION
本人に気づいてもらうのが一番ですが、
気づきにくいようなのと、公式のドキュメントを読んでもらうのはおすすめしたいので、最初から明記できればと思いました。

合わせて Reload に時間がかかるようになったので、連続タップの対応も必要になることを追記したい気もします。
何か良い書き方があれば