### PR TITLE
Upgrade actions/checkout v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       checks: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Test
         env:
           scheme: ${{ 'YumemiWeather' }}


### PR DESCRIPTION
サポートの終了した Node 16 から 20 への切り替え対応です。

[actions 実行時](https://github.com/yumemi-inc/ios-training/actions/runs/7956513879)に以下の警告が出力されています。

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, kishikawakatsumi/xcresulttool@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

kishikawakatsumi/xcresulttool の方は未対応です。 PR は作成されていました。

- https://github.com/kishikawakatsumi/xcresulttool/pull/760