### PR TITLE
複数行の文字列リテラルのインデントが周囲と乖離しないようにしました。

### DIFF
--- a/Tests/YumemiWeatherTests/YumemiWeatherListTests.swift
+++ b/Tests/YumemiWeatherTests/YumemiWeatherListTests.swift
@@ -26,11 +26,11 @@ final class YumemiWeatherListTests: XCTestCase {
     
     func test_fetchWeatherList_jsonString() {
         let parameter = """
-{
-    "areas": [],
-    "date": "2020-04-01T12:00:00+09:00"
-}
-"""
+        {
+            "areas": [],
+            "date": "2020-04-01T12:00:00+09:00"
+        }
+        """
         do {
             let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
             let dateFormatter = DateFormatter()
@@ -51,11 +51,11 @@ final class YumemiWeatherListTests: XCTestCase {
 
     func test_fetchWeatherList_jsonString_one() {
         let parameter = """
-{
-    "areas": ["Tokyo"],
-    "date": "2020-04-01T12:00:00+09:00"
-}
-"""
+        {
+            "areas": ["Tokyo"],
+            "date": "2020-04-01T12:00:00+09:00"
+        }
+        """
         do {
             let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
             let dateFormatter = DateFormatter()
@@ -83,11 +83,11 @@ final class YumemiWeatherListTests: XCTestCase {
 
     func test_fetchWeatherList_jsonString_two() {
         let parameter = """
-{
-    "areas": ["Tokyo", "Nagoya"],
-    "date": "2020-04-01T12:00:00+09:00"
-}
-"""
+        {
+            "areas": ["Tokyo", "Nagoya"],
+            "date": "2020-04-01T12:00:00+09:00"
+        }
+        """
         do {
             let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
             let dateFormatter = DateFormatter()
@@ -113,11 +113,11 @@ final class YumemiWeatherListTests: XCTestCase {
 
     func test_fetchWeatherList_jsonString_none() {
         let parameter = """
-{
-    "areas": ["LosAngeles"],
-    "date": "2020-04-01T12:00:00+09:00"
-}
-"""
+        {
+            "areas": ["LosAngeles"],
+            "date": "2020-04-01T12:00:00+09:00"
+        }
+        """
         do {
             let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
             let dateFormatter = DateFormatter()

--- a/Tests/YumemiWeatherTests/YumemiWeatherTests.swift
+++ b/Tests/YumemiWeatherTests/YumemiWeatherTests.swift
@@ -64,11 +64,11 @@ final class YumemiWeatherTests: XCTestCase {
 
     func test_fetchWeather_jsonString() {
         let parameter = """
-{
-    "area": "Tokyo",
-    "date": "2020-04-01T12:00:00+09:00"
-}
-"""
+        {
+            "area": "Tokyo",
+            "date": "2020-04-01T12:00:00+09:00"
+        }
+        """
         do {
             let responseJSON = try YumemiWeather.fetchWeather(parameter)
             let dateFormatter = DateFormatter()
@@ -89,11 +89,11 @@ final class YumemiWeatherTests: XCTestCase {
     func test_fetchWeather_jsonString_sync() {
         let beginDate = Date()
         let parameter = """
-{
-    "area": "Tokyo",
-    "date": "2020-04-01T12:00:00+09:00"
-}
-"""
+        {
+            "area": "Tokyo",
+            "date": "2020-04-01T12:00:00+09:00"
+        }
+        """
         do {
             let responseJSON = try YumemiWeather.syncFetchWeather(parameter)
             let dateFormatter = DateFormatter()
@@ -115,11 +115,11 @@ final class YumemiWeatherTests: XCTestCase {
 
     func test_fetchWeather_jsonString_callback() {
         let parameter = """
-{
-    "area": "Tokyo",
-    "date": "2020-04-01T12:00:00+09:00"
-}
-"""
+        {
+            "area": "Tokyo",
+            "date": "2020-04-01T12:00:00+09:00"
+        }
+        """
         let exp = expectation(description: #function)
         YumemiWeather.callbackFetchWeather(parameter) { result in
             exp.fulfill()
@@ -142,11 +142,11 @@ final class YumemiWeatherTests: XCTestCase {
     func test_fetchWeather_jsonString_async() async {
         let beginDate = Date()
         let parameter = """
-{
-    "area": "Tokyo",
-    "date": "2020-04-01T12:00:00+09:00"
-}
-"""
+        {
+            "area": "Tokyo",
+            "date": "2020-04-01T12:00:00+09:00"
+        }
+        """
         do {
             let responseJSON = try await YumemiWeather.asyncFetchWeather(parameter)
             let dateFormatter = DateFormatter()


### PR DESCRIPTION
複数行文字列の内容上のインデントは閉じ記号の位置で揃えられるため、行頭に揃えなくても大丈夫です。

行頭に揃えると全体的なインデントが複雑になる印象を持つため、そのリテラルが使われるコード行のインデントに揃えて記載するようにしてみました。