### PR TITLE
YumemiWeather API が無作為にエラーを返す頻度をコントロール可能にしました。

### DIFF
--- a/Sources/YumemiWeather/YumemiWeather.APIQuality.swift
+++ b/Sources/YumemiWeather/YumemiWeather.APIQuality.swift
@@ -1,0 +1,54 @@
+//
+//  YumemiWeather.APIQuality.swift
+//
+//  
+//  Created by Tomohiro Kumagai on 2024/05/02
+//  
+//
+
+extension YumemiWeather {
+    
+    /// API の品質を表現します。
+    enum APIQuality {
+        case sometimesFails(probability: Double)
+        case alwaysFails
+        case neverFails
+    }
+}
+
+extension YumemiWeather {
+    
+    /// API の想定品質です。
+    static var apiQuality: APIQuality = .sometimesFails(probability: 0.25)
+    
+    static func whetherHit(with probability: Double) -> Bool {
+        return (0 ..< probability).contains(.random(in: 0 ..< 1))
+    }
+    
+    /// この場所に不安定要素を埋め込みます。
+    ///
+    /// 不安定さの度合いは `apiQuality` に依存します。
+    /// - Throws: YumemiError ここで失敗が生成されると YumemiWeatherError.unknownError が送出されます。
+    static func introduceInstability() throws {
+        
+        switch apiQuality {
+
+        case .neverFails:
+            return
+
+        case .sometimesFails(let probability) where !whetherHit(with: probability):
+            return
+
+        case .sometimesFails, .alwaysFails:
+            throw YumemiWeatherError.unknownError
+        }
+    }
+    
+    /// この場所に不安定要素を埋め込みます。
+    ///
+    /// 不安定さの度合いは `apiQuality` に依存します。
+    /// - Throws: YumemiError ここで失敗が生成されると YumemiWeatherError.unknownError が送出されます。
+    func introduceInstability() throws {
+        try Self.introduceInstability()
+    }
+}

--- a/Sources/YumemiWeather/YumemiWeather.swift
+++ b/Sources/YumemiWeather/YumemiWeather.swift
@@ -58,11 +58,8 @@ final public class YumemiWeather {
     ///   - area: 天気予報を取得する対象地域 example: "tokyo"
     /// - Returns: 天気状況を表す文字列 "sunny" or "cloudy" or "rainy"
     public static func fetchWeatherCondition(at area: String) throws -> String {
-        if Int.random(in: 0...4) == 4 {
-            throw YumemiWeatherError.unknownError
-        }
-
-        return makeRandomResponse().weatherCondition
+        try introduceInstability()
+        return self.makeRandomResponse().weatherCondition
     }
 
     /// 天気予報を読み込む API の JSON Version です。
@@ -98,10 +95,7 @@ final public class YumemiWeather {
         let response = makeRandomResponse(date: request.date)
         let responseData = try encoder.encode(response)
 
-        if Int.random(in: 0...4) == 4 {
-            throw YumemiWeatherError.unknownError
-        }
-
+        try introduceInstability()
         return String(data: responseData, encoding: .utf8)!
     }
 

--- a/Sources/YumemiWeather/YumemiWeatherList.swift
+++ b/Sources/YumemiWeather/YumemiWeatherList.swift
@@ -70,9 +70,7 @@ public extension YumemiWeather {
             throw YumemiWeatherError.invalidParameterError
         }
 
-        if Int.random(in: 0...4) == 4 {
-            throw YumemiWeatherError.unknownError
-        }
+        try introduceInstability()
 
         let areas = request.areas.isEmpty ? Area.allCases : request.areas.compactMap { Area(rawValue: $0) }
         let areaResponses = areas.map { area -> AreaResponse in

--- a/Tests/YumemiWeatherTests/TestMethods.swift
+++ b/Tests/YumemiWeatherTests/TestMethods.swift
@@ -1,0 +1,67 @@
+//
+//  TestMethods.swift
+//
+//  
+//  Created by Tomohiro Kumagai on 2024/05/02
+//  
+//
+
+import XCTest
+@testable import YumemiWeather
+
+/// 失敗数が想定内かを判定します。
+/// - Parameters:
+///   - probability: 失敗率です。
+///   - tryingCount: 総試行回数です。
+///   - failureCount: うち、失敗した回数です。
+///   - file: 判定コードが記載されたファイルです。
+///   - line: 判定コードが記載された行です。
+func XCTAssertFailureCount(probability: Double, tryingCount: Int, failureCount: Int, file: StaticString = #filePath, line: UInt = #line) {
+    
+    let estimatedFailureCount = Double(tryingCount) * probability
+    let expectedFailureMargin = Double(tryingCount) * 0.01
+
+    let expectedFailureRange = estimatedFailureCount - expectedFailureMargin ..< estimatedFailureCount + expectedFailureMargin
+
+    XCTAssertTrue(expectedFailureRange.contains(Double(failureCount)), "Failures: \(failureCount), Estimated failures = \(estimatedFailureCount)±\(expectedFailureMargin)", file: file, line: line)
+}
+
+/// YumemiWether API の品質をテストします。
+/// - Parameters:
+///   - tryingCount: 総試行回数です。
+///   - quality: API の想定品質です。
+///   - file: 判定コードが記載されたファイルです。
+///   - line: 判定コードが記載された行です。
+func XCTAssertAPIQuality(_ predicate: () throws -> Void, tryingCount: Int, quality: YumemiWeather.APIQuality, file: StaticString = #filePath, line: UInt = #line) {
+        
+    var succeededCount = 0
+    var failedCount = 0
+    
+    YumemiWeather.apiQuality = quality
+    
+    for _ in 0 ..< tryingCount {
+
+        switch Result(catching: predicate) {
+            
+        case .success():
+            succeededCount += 1
+            
+        case .failure(_):
+            failedCount += 1
+        }
+    }
+    
+    switch quality {
+        
+    case .neverFails:
+        XCTAssertEqual(succeededCount, tryingCount, file: file, line: line)
+        XCTAssertEqual(failedCount, 0, file: file, line: line)
+        
+    case .alwaysFails:
+        XCTAssertEqual(succeededCount, 0, file: file, line: line)
+        XCTAssertEqual(failedCount, tryingCount, file: file, line: line)
+
+    case .sometimesFails(let probability):
+        XCTAssertFailureCount(probability: probability, tryingCount: tryingCount, failureCount: failedCount, file: file, line: line)
+    }
+}

--- a/Tests/YumemiWeatherTests/YumemiWeatherListTests.swift
+++ b/Tests/YumemiWeatherTests/YumemiWeatherListTests.swift
@@ -3,6 +3,28 @@ import XCTest
 
 final class YumemiWeatherListTests: XCTestCase {
 
+    override func setUpWithError() throws {
+        YumemiWeather.apiQuality = .neverFails
+    }
+    
+    func test_APIは必ずしも成功しない() throws {
+        
+        let tryingCount = 15_000
+        let request = """
+        {
+            "area": "tokyo",
+            "date": "2020-04-01T12:00:00+09:00"
+        }
+        """
+        let predicate = { _ = try YumemiWeather.fetchWeather(request) }
+
+        XCTAssertAPIQuality(predicate, tryingCount: tryingCount, quality: .sometimesFails(probability: 0.25))
+        XCTAssertAPIQuality(predicate, tryingCount: tryingCount, quality: .sometimesFails(probability: 0.8))
+        XCTAssertAPIQuality(predicate, tryingCount: tryingCount, quality: .sometimesFails(probability: 0.05))
+        XCTAssertAPIQuality(predicate, tryingCount: tryingCount, quality: .alwaysFails)
+        XCTAssertAPIQuality(predicate, tryingCount: tryingCount, quality: .neverFails)
+    }
+    
     func test_Areasに空を指定したときに全ての地域が取得される() throws {
         
         let request = """
@@ -24,115 +46,83 @@ final class YumemiWeatherListTests: XCTestCase {
         XCTAssertEqual(response.map(\.area), Area.allCases)
     }
     
-    func test_fetchWeatherList_jsonString() {
+    func test_fetchWeatherList_jsonString() throws {
         let parameter = """
 {
     "areas": [],
     "date": "2020-04-01T12:00:00+09:00"
 }
 """
-        do {
-            let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            decoder.dateDecodingStrategy = .formatted(dateFormatter)
-            let response = try decoder.decode([AreaResponse].self, from: Data(responseJSON.utf8))
-            XCTAssertEqual(response.count, Area.allCases.count)
-        }
-        catch let error as YumemiWeatherError {
-            XCTAssertEqual(error, YumemiWeatherError.unknownError)
-        }
-        catch {
-            XCTFail()
-        }
+        let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        let response = try decoder.decode([AreaResponse].self, from: Data(responseJSON.utf8))
+        XCTAssertEqual(response.count, Area.allCases.count)
     }
 
-    func test_fetchWeatherList_jsonString_one() {
+    func test_fetchWeatherList_jsonString_one() throws {
         let parameter = """
 {
     "areas": ["Tokyo"],
     "date": "2020-04-01T12:00:00+09:00"
 }
 """
-        do {
-            let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            decoder.dateDecodingStrategy = .formatted(dateFormatter)
-            let response = try decoder.decode([AreaResponse].self, from: Data(responseJSON.utf8))
-            XCTAssertEqual(response.count, 1)
-            let tokyo = response.first
-            XCTAssertEqual(tokyo?.area, .Tokyo)
-
-            let responseJSON2 = try YumemiWeather.fetchWeatherList(parameter)
-            let response2 = try decoder.decode([AreaResponse].self, from: Data(responseJSON2.utf8))
-            let tokyo2 = response2.first
-            XCTAssertEqual(tokyo?.info, tokyo2?.info)
-        }
-        catch let error as YumemiWeatherError {
-            XCTAssertEqual(error, YumemiWeatherError.unknownError)
-        }
-        catch {
-            XCTFail()
-        }
+        let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        let response = try decoder.decode([AreaResponse].self, from: Data(responseJSON.utf8))
+        XCTAssertEqual(response.count, 1)
+        let tokyo = response.first
+        XCTAssertEqual(tokyo?.area, .Tokyo)
+        
+        let responseJSON2 = try YumemiWeather.fetchWeatherList(parameter)
+        let response2 = try decoder.decode([AreaResponse].self, from: Data(responseJSON2.utf8))
+        let tokyo2 = response2.first
+        XCTAssertEqual(tokyo?.info, tokyo2?.info)
     }
 
-    func test_fetchWeatherList_jsonString_two() {
+    func test_fetchWeatherList_jsonString_two() throws {
         let parameter = """
 {
     "areas": ["Tokyo", "Nagoya"],
     "date": "2020-04-01T12:00:00+09:00"
 }
 """
-        do {
-            let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            decoder.dateDecodingStrategy = .formatted(dateFormatter)
-            let response = try decoder.decode([AreaResponse].self, from: Data(responseJSON.utf8))
-            XCTAssertEqual(response.count, 2)
-            let tokyo = response.first(where: { $0.area == .Tokyo })
-            XCTAssertNotNil(tokyo)
-            let nagoya = response.first(where: { $0.area == .Nagoya })
-            XCTAssertNotNil(nagoya)
-            XCTAssertNotEqual(tokyo?.info, nagoya?.info)
-        }
-        catch let error as YumemiWeatherError {
-            XCTAssertEqual(error, YumemiWeatherError.unknownError)
-        }
-        catch {
-            XCTFail()
-        }
+        let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        let response = try decoder.decode([AreaResponse].self, from: Data(responseJSON.utf8))
+        XCTAssertEqual(response.count, 2)
+        let tokyo = response.first(where: { $0.area == .Tokyo })
+        XCTAssertNotNil(tokyo)
+        let nagoya = response.first(where: { $0.area == .Nagoya })
+        XCTAssertNotNil(nagoya)
+        XCTAssertNotEqual(tokyo?.info, nagoya?.info)
     }
 
-    func test_fetchWeatherList_jsonString_none() {
+    func test_fetchWeatherList_jsonString_none() throws {
         let parameter = """
 {
     "areas": ["LosAngeles"],
     "date": "2020-04-01T12:00:00+09:00"
 }
 """
-        do {
-            let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            decoder.dateDecodingStrategy = .formatted(dateFormatter)
-            let response = try decoder.decode([AreaResponse].self, from: Data(responseJSON.utf8))
-            XCTAssertEqual(response.count, 0)
-        }
-        catch let error as YumemiWeatherError {
-            XCTAssertEqual(error, YumemiWeatherError.unknownError)
-        }
-        catch {
-            XCTFail()
-        }
+        let responseJSON = try YumemiWeather.fetchWeatherList(parameter)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        let response = try decoder.decode([AreaResponse].self, from: Data(responseJSON.utf8))
+        XCTAssertEqual(response.count, 0)
     }
 }

--- a/Tests/YumemiWeatherTests/YumemiWeatherTests.swift
+++ b/Tests/YumemiWeatherTests/YumemiWeatherTests.swift
@@ -3,6 +3,10 @@ import XCTest
 
 final class YumemiWeatherTests: XCTestCase {
 
+    override func setUpWithError() throws {
+        YumemiWeather.apiQuality = .neverFails
+    }
+
     func test_ランダムにレスポンスを生成する() {
 
         // 日付を省略すると実行した瞬間のものが得られてしまうため、
@@ -49,44 +53,28 @@ final class YumemiWeatherTests: XCTestCase {
         XCTAssertNotNil(WeatherCondition(rawValue: str))
     }
 
-    func test_fetchWeather_at() {
-        do {
-            let str = try YumemiWeather.fetchWeatherCondition(at: "tokyo")
-            XCTAssertNotNil(WeatherCondition(rawValue: str))
-        }
-        catch let error as YumemiWeatherError {
-            XCTAssertEqual(error, YumemiWeatherError.unknownError)
-        }
-        catch {
-            XCTFail()
-        }
+    func test_fetchWeather_at() throws {
+        let str = try YumemiWeather.fetchWeatherCondition(at: "tokyo")
+        XCTAssertNotNil(WeatherCondition(rawValue: str))
     }
 
-    func test_fetchWeather_jsonString() {
+    func test_fetchWeather_jsonString() throws {
         let parameter = """
 {
     "area": "tokyo",
     "date": "2020-04-01T12:00:00+09:00"
 }
 """
-        do {
-            let responseJSON = try YumemiWeather.fetchWeather(parameter)
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            decoder.dateDecodingStrategy = .formatted(dateFormatter)
-            _ = try decoder.decode(Response.self, from: Data(responseJSON.utf8))
-        }
-        catch let error as YumemiWeatherError {
-            XCTAssertEqual(error, YumemiWeatherError.unknownError)
-        }
-        catch {
-            XCTFail()
-        }
+        let responseJSON = try YumemiWeather.fetchWeather(parameter)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        _ = try decoder.decode(Response.self, from: Data(responseJSON.utf8))
     }
 
-    func test_fetchWeather_jsonString_sync() {
+    func test_fetchWeather_jsonString_sync() throws {
         let beginDate = Date()
         let parameter = """
 {
@@ -94,21 +82,13 @@ final class YumemiWeatherTests: XCTestCase {
     "date": "2020-04-01T12:00:00+09:00"
 }
 """
-        do {
-            let responseJSON = try YumemiWeather.syncFetchWeather(parameter)
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            decoder.dateDecodingStrategy = .formatted(dateFormatter)
-            _ = try decoder.decode(Response.self, from: Data(responseJSON.utf8))
-        }
-        catch let error as YumemiWeatherError {
-            XCTAssertEqual(error, YumemiWeatherError.unknownError)
-        }
-        catch {
-            XCTFail()
-        }
+        let responseJSON = try YumemiWeather.syncFetchWeather(parameter)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        _ = try decoder.decode(Response.self, from: Data(responseJSON.utf8))
 
         XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(beginDate), YumemiWeather.apiDuration)
     }
@@ -139,7 +119,7 @@ final class YumemiWeatherTests: XCTestCase {
     }
 
     @available(iOS 13, macOS 10.15, *)
-    func test_fetchWeather_jsonString_async() async {
+    func test_fetchWeather_jsonString_async() async throws {
         let beginDate = Date()
         let parameter = """
 {
@@ -147,21 +127,13 @@ final class YumemiWeatherTests: XCTestCase {
     "date": "2020-04-01T12:00:00+09:00"
 }
 """
-        do {
-            let responseJSON = try await YumemiWeather.asyncFetchWeather(parameter)
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
-            let decoder = JSONDecoder()
-            decoder.keyDecodingStrategy = .convertFromSnakeCase
-            decoder.dateDecodingStrategy = .formatted(dateFormatter)
-            _ = try decoder.decode(Response.self, from: Data(responseJSON.utf8))
-        }
-        catch let error as YumemiWeatherError {
-            XCTAssertEqual(error, YumemiWeatherError.unknownError)
-        }
-        catch {
-            XCTFail()
-        }
+        let responseJSON = try await YumemiWeather.asyncFetchWeather(parameter)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .formatted(dateFormatter)
+        _ = try decoder.decode(Response.self, from: Data(responseJSON.utf8))
 
         XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(beginDate), YumemiWeather.apiDuration)
     }


### PR DESCRIPTION
YumemiWeather API が無作為にエラーを発生させるタイミングを制御できないとテストコードの記載に支障をきたすため、Internal プロテクションレベルからであれば発生タイミングをカスタマイズ可能にしました。