### PR TITLE
不必要な import を削除しました。

### DIFF
--- a/Example/Example/Data/Weather.swift
+++ b/Example/Example/Data/Weather.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2020 YUMEMI Inc. All rights reserved.
 //
 
-import Foundation
-
 enum Weather: String, Decodable {
     case sunny
     case cloudy

--- a/Example/Example/Data/WeatherError.swift
+++ b/Example/Example/Data/WeatherError.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2020 YUMEMI Inc. All rights reserved.
 //
 
-import Foundation
-
 enum WeatherError: Error {
     case jsonEncodeError
     case jsonDecodeError

--- a/Example/Example/Model/DisasterModel.swift
+++ b/Example/Example/Model/DisasterModel.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 YUMEMI Inc. All rights reserved.
 //
 
-import Foundation
 import YumemiWeather
 
 class DisasterModelImpl: DisasterModel {

--- a/Sources/YumemiWeather/YumemiDisaster.swift
+++ b/Sources/YumemiWeather/YumemiDisaster.swift
@@ -5,8 +5,6 @@
 //  Created by 渡部 陽太 on 2020/04/19.
 //
 
-import Foundation
-
 public protocol YumemiDisasterHandleDelegate: AnyObject {
     func handle(disaster: String)
 }


### PR DESCRIPTION
必要性のない `import Foundation` を削除してみました。

削除しなくても支障のないところなのと、一般に Foundation は必要性に関係なく取り込むこともある様子なので、方針によってはこの PR は適用しない選択もあるかもしれません。