### PR TITLE
CI 修復

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
           cd ${{ matrix.config.dir }}
           rm -rf "${{ matrix.config.scheme }}".xcresult
-          xcodebuild -scheme "${{ matrix.config.scheme }}" -resultBundlePath "${{ matrix.config.scheme }}".xcresult test -destination "platform=$platform,name=$device"
+          xcodebuild -scheme "${{ matrix.config.scheme }}" -resultBundlePath ${{ matrix.config.scheme }} test -destination "platform=$platform,name=$device"
       - name: Report
         uses: kishikawakatsumi/xcresulttool@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,6 @@ jobs:
           # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
           device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
           cd ${{ matrix.config.dir }}
-          rm -rf "${{ matrix.config.scheme }}".xcresult
           xcodebuild -scheme "${{ matrix.config.scheme }}" -resultBundlePath ${{ matrix.config.scheme }} test -destination "platform=$platform,name=$device"
       - name: Report
         uses: kishikawakatsumi/xcresulttool@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,45 +2,32 @@ name: Test
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request_target:
-    branches: ["main"]
+    branches: [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.setmatrix.outputs.matrix }}
-    steps:
-      - id: setmatrix
-        run: |
-          object="[{\"scheme\":\"YumemiWeather\",\"dir\":\".\"},{\"scheme\":\"Example\",\"dir\":\"Example\"}]"
-          echo "matrix=$object" >> $GITHUB_OUTPUT
-  test:
-    needs: setup
+  build:
     runs-on: macos-latest
     permissions:
       contents: read
       checks: write
-    strategy:
-      matrix:
-        config: ${{fromJson(needs.setup.outputs.matrix)}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Test
         env:
+          scheme: ${{ 'YumemiWeather' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
           # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
           device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
-          cd ${{ matrix.config.dir }}
-          xcodebuild -scheme "${{ matrix.config.scheme }}" -resultBundlePath ${{ matrix.config.scheme }} test -destination "platform=$platform,name=$device"
-      - name: Report
+          xcodebuild -scheme "$scheme" -resultBundlePath TestResults test -destination "platform=$platform,name=$device"
+      - name: Format
         uses: kishikawakatsumi/xcresulttool@v1
         with:
-          path: ${{ matrix.config.scheme }}.xcresult
+          path: TestResults.xcresult
         if: success() || failure()

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 xcuserdata/
 DerivedData/
 docs
-/Example.xcresult
 
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project


### PR DESCRIPTION
現状の CI 修復が難しそうなので CI がパスしている以下のコミットの時点まで一度元に戻します

- 2b29eb4bc05b844cdeda3034de5c301bfcab173c

GitHub Action の性質上、この PR の CI は変更前の状態で動くためパスしないです。

以下 PR で、Example プロジェクトのビルドとテストを導入してもらいましたが、 Example にはテストがビルドエラーになるバグを意図して混入させているため、 CI を導入しにくいです。ビルドだけならできなくはないはずですが、ビルドが壊れているのを課題とする判断もありかもしれません。

## 動作確認
該当マージコミットの PR branch を restore して Action を実行してパスすることを確認しました

- #85 

https://github.com/yumemi-inc/ios-training/actions/runs/12504707219

同様に下記マージコミットの PR branch を restore して Action を実行すると失敗することを確認しました

- #86

https://github.com/yumemi-inc/ios-training/actions/runs/12495208606