### PR TITLE
ゆめみ表記の変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 株式会社ゆめみ iOS研修
+# ゆめみ iOS研修
 
 [![Test](https://github.com/yumemi-inc/ios-training/actions/workflows/test.yml/badge.svg)](https://github.com/yumemi-inc/ios-training/actions/workflows/test.yml)
 


### PR DESCRIPTION
次の理由から、「株式会社ゆめみ」を「ゆめみ」にリネームしました

- 株式会社ゆめみがアクセンチュアに吸収された
- ゆめみはブランドとして継続する
- この変更内容は広報確認済みです

### refs
- https://github.com/yumemi-inc/ios-engineer-codecheck/pull/24

## 該当箇所チェック
- [x] https://github.com/search?q=repo%3Aymm-oss%2Fios-training%20株式会社ゆめみ&type=code