### PR TITLE
Pages リンクのリポジトリ所有者を ymm-oss に修正

### DIFF
--- a/Documentation/YumemiWeather.md
+++ b/Documentation/YumemiWeather.md
@@ -13,11 +13,11 @@ SwiftPackageManagerに対応しています。
 
 ## API
 
-- [YumemiWeather](https://yumemi-inc.github.io/ios-training/documentation/yumemiweather/yumemiweather)
+- [YumemiWeather](https://ymm-oss.github.io/ios-training/documentation/yumemiweather/yumemiweather)
 
 ## Error type
 
-- [YumemiWeatherError](https://yumemi-inc.github.io/ios-training/documentation/yumemiweather/yumemiweathererror)
+- [YumemiWeatherError](https://ymm-oss.github.io/ios-training/documentation/yumemiweather/yumemiweathererror)
 
 ## 附録
 [関連ワード・動画索引（熊谷さんのやさしい Swift 勉強会）](https://yumemi.notion.site/f887eb4563a9434ab27c521fee9fbace)


### PR DESCRIPTION
## Summary
- 組織移管 (`yumemi-inc` → `ymm-oss`) 後、`Documentation/YumemiWeather.md` の Pages リンク 2 件 (`yumemi-inc.github.io/ios-training/...`) が 404 になっていたため、`ymm-oss.github.io/ios-training/...` に差し替え
- 新ホストでの配信は HTTP 200 を確認済み

## Why Pages だけ壊れたか
- `github.com/<owner>/<repo>` は org rename に対して 301 redirect が効くが、`<owner>.github.io` ホスト名は redirect 対象外のため、Pages の URL だけ 404 になった

## 今回スコープ外（参考）
- `README.md` の Test バッジ URL
- `Documentation/YumemiWeather.md:9` の SPM 用 URL (`https://github.com/yumemi-inc/ios-training.git`)
- これらは GitHub.com 側 redirect で動作するため変更しない

## Test plan
- [x] 旧 URL の 404 を curl で確認
- [x] 新 URL の 200 を curl で確認
- [ ] レンダリング後の Markdown でリンクがクリックで開けることを GitHub 上で目視確認